### PR TITLE
Fix random panics during autoballonning.

### DIFF
--- a/appvm.go
+++ b/appvm.go
@@ -310,6 +310,10 @@ func autoBalloon(l *libvirt.Libvirt, memoryMin, adjustPercent uint64) {
 				log.Println(err)
 				continue
 			}
+			if len(memoryUsedRaw) == 0 {
+				log.Println("Empty .memory_used file for domain", name)
+				continue
+			}
 			memoryUsedMiB, err := strconv.Atoi(string(memoryUsedRaw[0 : len(memoryUsedRaw)-1]))
 			if err != nil {
 				log.Println(err)


### PR DESCRIPTION
There is a race condition, when good behaving VMs will temporarily
truncate .memory_used to 0 bytes (update is not atomic).

Also, as a matter of principle, VMs should not crash the host,
ever.

<!-- Makes sure these boxes are checked before submitting your pull request -- thank you! -->

- [x] I tested it locally.
- [x] I tried to run at least one application VM and it works.
- [x] This checkboxes are not 100% relevant but yeah, I've reproduced both the problem and the fix.
