### PR TITLE
Update defaultSession to a new format

### DIFF
--- a/base.nix.go
+++ b/base.nix.go
@@ -16,6 +16,7 @@ var base_nix = `
   services.xserver = {
     enable = true;
     desktopManager.xterm.enable = false;
+    displayManager.defaultSession = "none+xmonad";
     displayManager.lightdm = {
       enable = true;
       autoLogin = {
@@ -24,7 +25,6 @@ var base_nix = `
       };
     };
     windowManager.xmonad.enable = true;
-    windowManager.default = "xmonad";
   };
 
   services.spice-vdagentd.enable = true;


### PR DESCRIPTION
My journey to this commit was long. At first, I've suddenly got this:

```
trace: Default graphical session, 'xmonad', not found.
Valid names for 'services.xserver.displayManager.defaultSession' are:
  none+xmonad

error: The option value `services.xserver.displayManager.defaultSession' ...
(use '--show-trace' to show detailed location information)
2020/04/01 03:22:15 <nil> [] []
2020/04/01 03:22:15 ret code: 1, out: [], err: []
```

So I've added this:

```diff
--- a/base.nix.go
+++ b/base.nix.go
@@ -16,6 +16,7 @@ var base_nix = `
   services.xserver = {
     enable = true;
     desktopManager.xterm.enable = false;
+    desktopManager.default = "none";
     displayManager.lightdm = {
       enable = true;
       autoLogin = {
```

But:

```
trace: warning: The following options are deprecated:
  - services.xserver.desktopManager.default
  - services.xserver.windowManager.default
Please use
  services.xserver.displayManager.defaultSession = "none+xmonad";
instead.
```

So that's what I did (and removed old option because "You cannot use both
services.xserver.displayManager.defaultSession option and legacy options").

Does it make sense? It certainly helps in my case.

<!-- Makes sure these boxes are checked before submitting your pull request -- thank you! -->

- [x] I tested it locally.
- [x] I tried to run at least one application VM and it works.
