### PR TITLE
Add terminal-only appvms

### DIFF
--- a/appvm.go
+++ b/appvm.go
@@ -168,14 +168,14 @@ func isRunning(l *libvirt.Libvirt, name string) bool {
 
 func generateAppVM(l *libvirt.Libvirt,
 	nixName, vmName, appvmPath, sharedDir string,
-	verbose, online bool) (err error) {
+	verbose, online, gui bool) (err error) {
 
 	realpath, reginfo, qcow2, err := generateVM(appvmPath, nixName, verbose)
 	if err != nil {
 		return
 	}
 
-	xml := generateXML(vmName, online, realpath, reginfo, qcow2, sharedDir)
+	xml := generateXML(vmName, online, gui, realpath, reginfo, qcow2, sharedDir)
 	_, err = l.DomainCreateXML(xml, libvirt.DomainStartValidate)
 	return
 }
@@ -204,7 +204,7 @@ func isAppvmConfigurationExists(appvmPath, name string) bool {
 	return fileExists(appvmPath + "/nix/" + name + ".nix")
 }
 
-func start(l *libvirt.Libvirt, name string, verbose, online, stateless bool,
+func start(l *libvirt.Libvirt, name string, verbose, online, gui, stateless bool,
 	args, open string) {
 
 	appvmPath := configDir
@@ -262,14 +262,16 @@ func start(l *libvirt.Libvirt, name string, verbose, online, stateless bool,
 		}
 
 		err := generateAppVM(l, name, vmName, appvmPath, sharedDir,
-			verbose, online)
+			verbose, online, gui)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	cmd := exec.Command("virt-viewer", "-c", "qemu:///system", vmName)
-	cmd.Start()
+	if gui {
+		cmd := exec.Command("virt-viewer", "-c", "qemu:///system", vmName)
+		cmd.Start()
+	}
 }
 
 func stop(l *libvirt.Libvirt, name string) {
@@ -445,6 +447,7 @@ func main() {
 	startArgs := startCommand.Flag("args", "Command line arguments").String()
 	startOpen := startCommand.Flag("open", "Pass file to application").String()
 	startOffline := startCommand.Flag("offline", "Disconnect").Bool()
+	startCli := startCommand.Flag("cli", "Disable graphics mode, enable serial").Bool()
 	startStateless := startCommand.Flag("stateless", "Do not use default state directory").Bool()
 
 	stopName := kingpin.Command("stop", "Stop application").Arg("name", "Application name").Required().String()
@@ -491,7 +494,7 @@ func main() {
 			*generateBuildVM)
 	case "start":
 		start(l, *startName,
-			!*startQuiet, !*startOffline, *startStateless,
+			!*startQuiet, !*startOffline, !*startCli, *startStateless,
 			*startArgs, *startOpen)
 	case "stop":
 		stop(l, *stopName)


### PR DESCRIPTION
<!-- Makes sure these boxes are checked before submitting your pull request -- thank you! -->

- [x] I tested it locally.
- [x] I tried to run at least one application VM and it works.

##  Add terminal-only appvms

I hope this change is not too controversial.

Sometimes I want to run a VM without a window running in the foreground.
For example, a router/firewall VM, temporary VM for compiling some untrusted
code or installing a random package from the internet. Full GUI is usually
unnecessary, since it's much nicer to be able to use host's terminal directly.

In this change I add `--cli` switch that disables GUI window.

Initially I also added serial device to domain (this allowed automatic connect
with `virsh -c qemu:///system console appvm_name`), but I dropped it before
making a PR - adding a SSH server to appvm definition works better for me.

I also change networking model from qemu to virtmanager's device (virbr0).
The reason for this is that it's much easier for me to configure firewall/
iptables with virt manager network, than with qemu device. Also AppVMs
don't have IPs with qemu device, I think. If this change is not OK I'm
happy to keep this change only in my fork (or maybe as a switch
`--networking-model`?)

Thoughts?