### PR TITLE
Fix build and boot errors on NixOS 21.11

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,8 +18,7 @@ buildGoModule rec {
 
   src = ./.;
 
-  vendorSha256 = "1aimli23jdqv8rifsn22qfbj2c0nc0s5czsd8qprhnr4hcsbdnkf";
-  modSha256 = "${vendorSha256}"; # backward compatibility
+  vendorSha256 = "sha256-8eU+Mf5dxL/bAMMShXvj8I1Kdd4ysBTWvgYIXwLStPI=";
 
   postFixup = ''
     wrapProgram $out/bin/appvm \

--- a/default.nix
+++ b/default.nix
@@ -16,8 +16,6 @@ buildGoModule rec {
 
   buildInputs = [ makeWrapper ];
 
-  goPackagePath = "code.dumpstack.io/tools/${pname}";
-
   src = ./.;
 
   vendorSha256 = "1aimli23jdqv8rifsn22qfbj2c0nc0s5czsd8qprhnr4hcsbdnkf";

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ First, clone this repo. Then do this:
     /path/to/repo/nixos
   ];
 
-  virtualizatiom.appvm = {
+  virtualisation.appvm = {
     enable = true;
     user = "${username}";
   };

--- a/xml.go
+++ b/xml.go
@@ -93,7 +93,7 @@ var xmlTmpl = `
     <!-- filesystems -->
     <filesystem type='mount' accessmode='passthrough'>
       <source dir='/nix/store'/>
-      <target dir='store'/>
+      <target dir='nix-store'/>
       <readonly/>
     </filesystem>
     <filesystem type='mount' accessmode='mapped'>


### PR DESCRIPTION
Fix building the nix module and error while booting the VM on NixOS 21.11.

Trying to run 2 VMs at a time still results in the following error though:
```
2021/12/20 11:59:28 internal error: process exited while connecting to monitor: qemu-system-x86_64: -fsdev local,security_model=passthrough,id=fsdev-fs0,path=/nix/store,readonly: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
2021-12-20T10:59:28.668638Z qemu-system-x86_64: -blockdev {"node-name":"libvirt-1-format","read-only":false,"cache":{"direct":false,"no-flush":false},"driver":"qcow2","file":"libvirt-1-storage","backing":null}: Failed to get "write" lock
Is another process using the image [/home/ilian/appvm/.fake.qcow2]?
```
---
- [x] I tested it locally.
- [x] I tried to run at least one application VM and it works.
