### PR TITLE
fix ethernet device pci slot conflict

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -35,7 +35,7 @@ var qemuParamsDefault = `
 var qemuParamsWithNetwork = `
   <qemu:commandline>
     <qemu:arg value='-device'/>
-    <qemu:arg value='e1000,netdev=net0'/>
+    <qemu:arg value='e1000,netdev=net0,bus=pci.0,addr=0x10'/>
     <qemu:arg value='-netdev'/>
     <qemu:arg value='user,id=net0'/>
     <qemu:arg value='-snapshot'/>


### PR DESCRIPTION
This PR fixes issue https://github.com/jollheef/appvm/issues/29 .
It seems that newer versions of Qemu hardcodes the e1000 ethernet device to PCI bus 0 slot 2. This conflicts with all the other dynamically added devices later. 
This patch assigns e1000 to the free slot 10, so starting VMs work again :)

- [x] I tested it locally.
- [x] I tried to run at least one application VM and it works.
